### PR TITLE
feat: added support for hash, from-hash, and to-hash argument

### DIFF
--- a/src/commitlint/cli.py
+++ b/src/commitlint/cli.py
@@ -17,8 +17,10 @@ import os
 import sys
 from typing import List
 
-from .commitlint import check_commit_message
-from .messages import COMMIT_SUCCESSFUL
+from .commitlint import check_commit_message, remove_comments
+from .exceptions import CommitlintException
+from .git_helpers import get_commit_message_of_hash, get_commit_messages_of_hash_range
+from .messages import VALIDATION_SUCCESSFUL
 
 
 def get_args() -> argparse.Namespace:
@@ -34,34 +36,105 @@ def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Check if a commit message follows the conventional commit format."
     )
-    parser.add_argument(
+
+    # for commit message check
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
         "commit_message", nargs="?", type=str, help="The commit message to be checked."
     )
-    parser.add_argument(
+    group.add_argument(
         "--file", type=str, help="Path to a file containing the commit message."
     )
+    group.add_argument("--hash", type=str, help="Commit hash")
+    group.add_argument("--from-hash", type=str, help="From commit hash")
+    # --to-hash is optional
+    parser.add_argument("--to-hash", type=str, help="To commit hash", default="HEAD")
 
+    # parsing args
     args = parser.parse_args()
-
-    if not args.file and not args.commit_message:
-        parser.error("Please provide either a commit message or a file.")
 
     return args
 
 
-def _show_errors(errors: List[str]) -> None:
+def _show_errors(commit_message: str, errors: List[str]) -> None:
     """
     Display a formatted error message for a list of errors.
 
     Args:
         errors (List[str]): A list of error messages to be displayed.
+    """
+    error_count = len(errors)
+    commit_message = remove_comments(commit_message)
+
+    sys.stderr.write(
+        f"⧗ Input:\n{commit_message}\n\n✖ Found {error_count} error(s).\n\n"
+    )
+    for index, error in enumerate(errors):
+        end_char = "" if index == error_count - 1 else "\n"
+        sys.stderr.write(f"- {error}\n{end_char}")
+
+
+def _get_commit_message_from_file(filepath: str) -> str:
+    """
+    Reads and returns the commit message from the specified file.
+
+    Args:
+        filepath (str): The path to the file containing the commit message.
 
     Returns:
-        None
+        str: The commit message read from the file.
+
+    Raises:
+        FileNotFoundError: If the specified file does not exist.
+        IOError: If there is an issue reading the file.
     """
-    sys.stderr.write(f"✖ Found {len(errors)} errors.\n\n")
-    for error in errors:
-        sys.stderr.write(f"- {error}\n\n")
+    abs_filepath = os.path.abspath(filepath)
+    with open(abs_filepath, encoding="utf-8") as commit_message_file:
+        commit_message = commit_message_file.read().strip()
+        return commit_message
+
+
+def _handle_commit_message(commit_message: str) -> None:
+    """
+    Handles a single commit message, checks its validity, and prints the result.
+
+    Args:
+        commit_message (str): The commit message to be handled.
+
+    Raises:
+        SystemExit: If the commit message is invalid.
+    """
+    success, errors = check_commit_message(commit_message)
+
+    if success:
+        sys.stdout.write(f"{VALIDATION_SUCCESSFUL}\n")
+    else:
+        _show_errors(commit_message, errors)
+        sys.exit(1)
+
+
+def _handle_multiple_commit_messages(commit_messages: List[str]) -> None:
+    """
+    Handles multiple commit messages, checks their validity, and prints the result.
+
+    Args:
+        commit_messages (List[str]): List of commit messages to be handled.
+
+    Raises:
+        SystemExit: If any of the commit messages is invalid.
+    """
+    has_error = False
+    for commit_message in commit_messages:
+        success, errors = check_commit_message(commit_message)
+        if not success:
+            has_error = True
+            _show_errors(commit_message, errors)
+            sys.stderr.write("\n")
+
+    if has_error:
+        sys.exit(1)
+    else:
+        sys.stdout.write(f"{VALIDATION_SUCCESSFUL}\n")
 
 
 def main() -> None:
@@ -70,20 +143,23 @@ def main() -> None:
     """
     args = get_args()
 
-    if args.file:
-        commit_message_filepath = os.path.abspath(args.file)
-        with open(commit_message_filepath, encoding="utf-8") as commit_message_file:
-            commit_message = commit_message_file.read().strip()
-    else:
-        commit_message = args.commit_message.strip()
-
-    success, errors = check_commit_message(commit_message)
-
-    if success:
-        sys.stdout.write(f"{COMMIT_SUCCESSFUL}\n")
-        sys.exit(0)
-    else:
-        _show_errors(errors)
+    try:
+        if args.file:
+            commit_message = _get_commit_message_from_file(args.file)
+            _handle_commit_message(commit_message)
+        elif args.hash:
+            commit_message = get_commit_message_of_hash(args.hash)
+            _handle_commit_message(commit_message)
+        elif args.from_hash:
+            commit_messages = get_commit_messages_of_hash_range(
+                args.from_hash, args.to_hash
+            )
+            _handle_multiple_commit_messages(commit_messages)
+        else:
+            commit_message = args.commit_message.strip()
+            _handle_commit_message(commit_message)
+    except CommitlintException as ex:
+        sys.stderr.write(f"{ex}\n")
         sys.exit(1)
 
 

--- a/src/commitlint/commitlint.py
+++ b/src/commitlint/commitlint.py
@@ -15,7 +15,7 @@ success, errors = check_commit_message(commit_message)
 import re
 from typing import List, Tuple
 
-from .constants import COMMIT_MAX_LENGTH
+from .constants import COMMIT_HEADER_MAX_LENGTH
 from .messages import HEADER_LENGTH_ERROR, INCORRECT_FORMAT_ERROR
 
 CONVENTIONAL_COMMIT_PATTERN = (
@@ -111,7 +111,7 @@ def check_commit_message(commit_message: str) -> Tuple[bool, List[str]]:
 
     # checking the length of header
     header = commit_message.split("\n").pop()
-    if len(header) > COMMIT_MAX_LENGTH:
+    if len(header) > COMMIT_HEADER_MAX_LENGTH:
         success = False
         errors.append(HEADER_LENGTH_ERROR)
 

--- a/src/commitlint/constants.py
+++ b/src/commitlint/constants.py
@@ -1,3 +1,3 @@
 """This module defines constants used throughout the application."""
 
-COMMIT_MAX_LENGTH = 72
+COMMIT_HEADER_MAX_LENGTH = 72

--- a/src/commitlint/exceptions.py
+++ b/src/commitlint/exceptions.py
@@ -1,0 +1,17 @@
+"""Custom exceptions module for Commitlint."""
+
+
+class CommitlintException(Exception):
+    """Base exception for Commitlint."""
+
+
+class GitException(CommitlintException):
+    """Exceptions related to Git."""
+
+
+class GitCommitNotFoundException(GitException):
+    """Exception raised when a Git commit could not be retrieved."""
+
+
+class GitInvalidCommitRangeException(GitException):
+    """Exception raised when an invalid commit range was provided."""

--- a/src/commitlint/git_helpers.py
+++ b/src/commitlint/git_helpers.py
@@ -1,0 +1,89 @@
+"""
+This module contains the git related helper functions.
+"""
+import subprocess
+from typing import List
+
+from .exceptions import GitCommitNotFoundException, GitInvalidCommitRangeException
+
+
+def get_commit_message_of_hash(commit_hash: str) -> str:
+    """
+    Retrieve the commit message for a given Git commit hash.
+
+    Args:
+        commit_hash (str): The Git commit hash for which the commit message is to
+            be retrieved.
+
+    Returns:
+        str: The commit message associated with the specified commit hash.
+
+    Raises:
+        GitCommitNotFoundException: If the specified commit hash is not found
+            or if there is an error retrieving the commit message.
+    """
+    try:
+        # Run 'git show --format=%B -s' command to get the commit message
+        commit_message = subprocess.check_output(
+            ["git", "show", "--format=%B", "-s", commit_hash],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+
+        return commit_message
+    except subprocess.CalledProcessError:
+        raise GitCommitNotFoundException(
+            f"Failed to retrieve commit message for hash {commit_hash}"
+        ) from None
+
+
+def get_commit_messages_of_hash_range(
+    from_hash: str, to_hash: str = "HEAD"
+) -> List[str]:
+    """
+    Retrieve an array of commit messages for a range of Git commit hashes.
+
+    Note:
+        This function will not support initial commit as from_hash.
+
+    Args:
+        from_hash (str): The starting Git commit hash.
+        to_hash (str, optional): The ending Git commit hash or branch
+            (default is "HEAD").
+
+    Returns:
+        List[str]: A list of commit messages for the specified commit range.
+
+    Raises:
+        GitCommitNotFoundException: If the commit hash of `from_hash` is not found
+            or if there is an error retrieving the commit message.
+
+        GitInvalidCommitRangeException: If the commit range of from_hash..to_hash is not
+            found or if there is an error retrieving the commit message.
+    """
+    # as the commit range doesn't support initial commit hash,
+    # commit message of `from_hash` is taken separately
+    from_commit_message = get_commit_message_of_hash(from_hash)
+
+    try:
+        # Runs the below git command:
+        # git log --format=%B --reverse FROM_HASH..TO_HASH
+        # This outputs the commit messages excluding of FROM_HASH
+        delimiter = "========commit-delimiter========"
+        hash_range = f"{from_hash}..{to_hash}"
+
+        commit_messages_output = subprocess.check_output(
+            ["git", "log", f"--format=%B{delimiter}", "--reverse", hash_range],
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+        commit_messages = commit_messages_output.split(f"{delimiter}\n")
+        return [from_commit_message] + [
+            commit_message.strip()
+            for commit_message in commit_messages
+            if commit_message.strip()
+        ]
+    except subprocess.CalledProcessError:
+        raise GitInvalidCommitRangeException(
+            f"Failed to retrieve commit messages for the range {from_hash} to {to_hash}"
+        ) from None

--- a/src/commitlint/messages.py
+++ b/src/commitlint/messages.py
@@ -2,9 +2,9 @@
 This module provides constant messages used in the application for various scenarios.
 """
 
-from .constants import COMMIT_MAX_LENGTH
+from .constants import COMMIT_HEADER_MAX_LENGTH
 
-COMMIT_SUCCESSFUL = "Commit validation: successful!"
+VALIDATION_SUCCESSFUL = "Commit validation: successful!"
 
 CORRECT_OUTPUT_FORMAT = (
     "Correct commit format:\n"
@@ -18,4 +18,6 @@ INCORRECT_FORMAT_ERROR = (
     "Commit message does not follow conventional commits format."
     f"\n{CORRECT_OUTPUT_FORMAT}"
 )
-HEADER_LENGTH_ERROR = f"Header must not be longer than {COMMIT_MAX_LENGTH} characters."
+HEADER_LENGTH_ERROR = (
+    f"Header must not be longer than {COMMIT_HEADER_MAX_LENGTH} characters."
+)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,54 +4,96 @@
 from unittest.mock import MagicMock, call, mock_open, patch
 
 from src.commitlint.cli import get_args, main
-from src.commitlint.messages import COMMIT_SUCCESSFUL, INCORRECT_FORMAT_ERROR
+from src.commitlint.exceptions import CommitlintException
+from src.commitlint.messages import INCORRECT_FORMAT_ERROR, VALIDATION_SUCCESSFUL
 
 
-class TestCLI:
+class TestCLIGetArgs:
+    # get_args
+
     @patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=MagicMock(commit_message="commit message", file=None),
+        return_value=MagicMock(
+            commit_message="commit message", file=None, hash=None, from_hash=None
+        ),
     )
     def test__get_args__with_commit_message(self, *_):
         args = get_args()
         assert args.commit_message == "commit message"
         assert args.file is None
+        assert args.hash is None
+        assert args.from_hash is None
 
     @patch(
         "argparse.ArgumentParser.parse_args",
-        return_value=MagicMock(commit_message=None, file="path/to/file.txt"),
+        return_value=MagicMock(file="path/to/file.txt"),
     )
     def test__get_args__with_file(self, *_):
         args = get_args()
         assert args.file == "path/to/file.txt"
-        assert args.commit_message is None
 
-    @patch("argparse.ArgumentParser.error")
-    def test__get_args__without_commit_message_and_file(self, mock_error):
-        get_args()
-        mock_error.assert_called_with(
-            "Please provide either a commit message or a file."
-        )
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=MagicMock(hash="commit_hash", file=None),
+    )
+    def test__get_args__with_hash(self, *_):
+        args = get_args()
+        assert args.hash == "commit_hash"
+        assert args.file is None
+
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=MagicMock(from_hash="from_commit_hash", file=None, hash=None),
+    )
+    def test__get_args__with_from_hash(self, *_):
+        args = get_args()
+        assert args.from_hash == "from_commit_hash"
+        assert args.file is None
+        assert args.hash is None
+
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=MagicMock(
+            from_hash="from_commit_hash", to_hash="to_commit_hash", file=None, hash=None
+        ),
+    )
+    def test__get_args__with_to_hash(self, *_):
+        args = get_args()
+        assert args.from_hash == "from_commit_hash"
+        assert args.to_hash == "to_commit_hash"
+        assert args.file is None
+        assert args.hash is None
+
+
+class TestCLIMain:
+    # main: commit_message
 
     @patch(
         "src.commitlint.cli.get_args",
-        return_value=MagicMock(commit_message="feat: valid commit message", file=None),
+        return_value=MagicMock(
+            commit_message="feat: valid commit message",
+            file=None,
+            hash=None,
+            from_hash=None,
+        ),
     )
     @patch("sys.stdout.write")
-    @patch("sys.exit")
     def test__main__valid_commit_message(
         self,
-        mock_sys_exit,
         mock_stdout_write,
         *_,
     ):
         main()
-        mock_sys_exit.assert_called_with(0)
-        mock_stdout_write.assert_called_with(f"{COMMIT_SUCCESSFUL}\n")
+        mock_stdout_write.assert_called_with(f"{VALIDATION_SUCCESSFUL}\n")
 
     @patch(
         "src.commitlint.cli.get_args",
-        return_value=MagicMock(commit_message="Invalid commit message", file=None),
+        return_value=MagicMock(
+            commit_message="Invalid commit message",
+            file=None,
+            hash=None,
+            from_hash=None,
+        ),
     )
     @patch("sys.stderr.write")
     @patch("sys.exit")
@@ -64,35 +106,140 @@ class TestCLI:
         main()
         mock_sys_exit.assert_called_with(1)
         mock_stderr_write.assert_has_calls(
-            [call("✖ Found 1 errors.\n\n"), call(f"- {INCORRECT_FORMAT_ERROR}\n\n")]
+            [
+                call("⧗ Input:\nInvalid commit message\n\n✖ Found 1 error(s).\n\n"),
+                call(f"- {INCORRECT_FORMAT_ERROR}\n"),
+            ]
         )
 
-    @patch(
-        "src.commitlint.cli.get_args",
-        return_value=MagicMock(file="path/to/file.txt", commit_message=None),
-    )
-    @patch("sys.stdout.write")
-    @patch("sys.exit")
-    @patch("builtins.open", mock_open(read_data="feat: valid commit message"))
-    def test__main__valid_commit_message_from_file(
-        self, mock_sys_exit, mock_stdout_write, *_
-    ):
-        main()
-        mock_sys_exit.assert_called_with(0)
-        mock_stdout_write.assert_called_with(f"{COMMIT_SUCCESSFUL}\n")
+    # main: file
 
     @patch(
         "src.commitlint.cli.get_args",
-        return_value=MagicMock(file="path/to/file.txt", commit_message=None),
+        return_value=MagicMock(file="path/to/file.txt"),
+    )
+    @patch("sys.stdout.write")
+    @patch("builtins.open", mock_open(read_data="feat: valid commit message"))
+    def test__main__valid_commit_message_with_file(self, mock_stdout_write, *_):
+        main()
+        mock_stdout_write.assert_called_with(f"{VALIDATION_SUCCESSFUL}\n")
+
+    @patch(
+        "src.commitlint.cli.get_args",
+        return_value=MagicMock(file="path/to/file.txt"),
     )
     @patch("sys.stderr.write")
     @patch("sys.exit")
     @patch("builtins.open", mock_open(read_data="Invalid commit message"))
-    def test__main__invalid_commit_message_from_file(
+    def test__main__invalid_commit_message_with_file(
         self, mock_sys_exit, mock_stderr_write, *_
     ):
         main()
         mock_sys_exit.assert_called_with(1)
         mock_stderr_write.assert_has_calls(
-            [call("✖ Found 1 errors.\n\n"), call(f"- {INCORRECT_FORMAT_ERROR}\n\n")]
+            [
+                call("⧗ Input:\nInvalid commit message\n\n✖ Found 1 error(s).\n\n"),
+                call(f"- {INCORRECT_FORMAT_ERROR}\n"),
+            ]
         )
+
+    # main: hash
+
+    @patch(
+        "src.commitlint.cli.get_args",
+        return_value=MagicMock(file=None, hash="commit_hash"),
+    )
+    @patch("src.commitlint.cli.get_commit_message_of_hash")
+    @patch("sys.stdout.write")
+    def test__main__valid_commit_message_with_hash(
+        self, mock_stdout_write, mock_get_commit_message_of_hash, *_
+    ):
+        mock_get_commit_message_of_hash.return_value = "feat: valid commit message"
+        main()
+        mock_stdout_write.assert_called_with(f"{VALIDATION_SUCCESSFUL}\n")
+
+    @patch(
+        "src.commitlint.cli.get_args",
+        return_value=MagicMock(file=None, hash="commit_hash"),
+    )
+    @patch("src.commitlint.cli.get_commit_message_of_hash")
+    @patch("sys.stderr.write")
+    @patch("sys.exit")
+    def test__main__invalid_commit_message_with_hash(
+        self, mock_sys_exit, mock_stderr_write, mock_get_commit_message_of_hash, *_
+    ):
+        mock_get_commit_message_of_hash.return_value = "Invalid commit message"
+        main()
+        mock_sys_exit.assert_called_with(1)
+        mock_stderr_write.assert_has_calls(
+            [
+                call("⧗ Input:\nInvalid commit message\n\n✖ Found 1 error(s).\n\n"),
+                call(f"- {INCORRECT_FORMAT_ERROR}\n"),
+            ]
+        )
+
+    # main: from_hash and to_hash
+
+    @patch(
+        "src.commitlint.cli.get_args",
+        return_value=MagicMock(
+            file=None,
+            hash=None,
+            from_hash="start_commit_hash",
+            to_hash="end_commit_hash",
+        ),
+    )
+    @patch("src.commitlint.cli.get_commit_messages_of_hash_range")
+    @patch("sys.stdout.write")
+    def test__main__valid_commit_message_with_hash_range(
+        self, mock_stdout_write, mock_get_commit_messages, *_
+    ):
+        mock_get_commit_messages.return_value = [
+            "feat: commit message 1",
+            "fix: commit message 2",
+        ]
+        main()
+        mock_stdout_write.assert_called_with(f"{VALIDATION_SUCCESSFUL}\n")
+
+    @patch(
+        "src.commitlint.cli.get_args",
+        return_value=MagicMock(
+            file=None,
+            hash=None,
+            from_hash="invalid_start_hash",
+            to_hash="end_commit_hash",
+        ),
+    )
+    @patch("sys.stderr.write")
+    @patch("src.commitlint.cli.get_commit_messages_of_hash_range")
+    @patch("sys.exit")
+    def test__main__invalid_commit_message_with_hash_range(
+        self, mock_sys_exit, mock_get_commit_messages, *_
+    ):
+        mock_get_commit_messages.return_value = [
+            "Invalid commit message 1",
+            "Invalid commit message 2",
+        ]
+        main()
+        mock_sys_exit.assert_called_with(1)
+
+    # main : exception handling
+
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=MagicMock(
+            commit_message="feat: commit message", file=None, hash=None, from_hash=None
+        ),
+    )
+    @patch(
+        "src.commitlint.cli.check_commit_message",
+    )
+    @patch("sys.stderr.write")
+    @patch("sys.exit")
+    def test__main__handle_exceptions(
+        self, mock_sys_exit, mock_stderr_write, mock_check_commit_message, *_
+    ):
+        mock_check_commit_message.side_effect = CommitlintException("Test message")
+        main()
+        mock_sys_exit.assert_called_with(1)
+        mock_stderr_write.assert_called_with("Test message\n")

--- a/tests/test_commitlint/test_check_commit_message.py
+++ b/tests/test_commitlint/test_check_commit_message.py
@@ -2,19 +2,19 @@
 # pylint: disable=all
 
 from src.commitlint import check_commit_message
-from src.commitlint.constants import COMMIT_MAX_LENGTH
+from src.commitlint.constants import COMMIT_HEADER_MAX_LENGTH
 from src.commitlint.messages import HEADER_LENGTH_ERROR, INCORRECT_FORMAT_ERROR
 
 
 def test__check_commit_message__header_length_error():
-    commit_message = "feat: " + "a" * (COMMIT_MAX_LENGTH + 1)
+    commit_message = "feat: " + "a" * (COMMIT_HEADER_MAX_LENGTH + 1)
     success, errors = check_commit_message(commit_message)
     assert success is False
     assert HEADER_LENGTH_ERROR in errors
 
 
 def test__check_commit_message__header_length_valid():
-    commit_message = "feat: " + "a" * (COMMIT_MAX_LENGTH - 1)
+    commit_message = "feat: " + "a" * (COMMIT_HEADER_MAX_LENGTH - 1)
     success, errors = check_commit_message(commit_message)
     assert success is False
     assert HEADER_LENGTH_ERROR in errors
@@ -28,7 +28,7 @@ def test__check_commit_message__incorrect_format_error():
 
 
 def test__check_commit_message__incorrect_format_error_and_health_length_invalid():
-    commit_message = "Test " + "a" * (COMMIT_MAX_LENGTH + 1)
+    commit_message = "Test " + "a" * (COMMIT_HEADER_MAX_LENGTH + 1)
     success, errors = check_commit_message(commit_message)
     assert success is False
     assert HEADER_LENGTH_ERROR in errors

--- a/tests/test_git_helpers.py
+++ b/tests/test_git_helpers.py
@@ -1,0 +1,105 @@
+# type: ignore
+# pylint: disable=all
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from src.commitlint.exceptions import (
+    GitCommitNotFoundException,
+    GitInvalidCommitRangeException,
+)
+from src.commitlint.git_helpers import (
+    get_commit_message_of_hash,
+    get_commit_messages_of_hash_range,
+)
+
+DELIMITER = "========commit-delimiter========"
+
+
+@pytest.fixture
+def mock_subprocess():
+    with patch("src.commitlint.git_helpers.subprocess") as mock_subprocess:
+        mock_subprocess.PIPE = subprocess.PIPE
+        mock_subprocess.CalledProcessError = subprocess.CalledProcessError
+        yield mock_subprocess
+
+
+def test_get_commit_message_of_hash_success(mock_subprocess):
+    hash_value = "abc123"
+    expected_output = "Commit message for abc123"
+    mock_subprocess.check_output.return_value = expected_output
+
+    result = get_commit_message_of_hash(hash_value)
+
+    assert result == expected_output
+    mock_subprocess.check_output.assert_called_once_with(
+        ["git", "show", "--format=%B", "-s", hash_value],
+        text=True,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_get_commit_message_of_hash_failure(mock_subprocess):
+    hash_value = "invalid_hash"
+
+    mock_subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        returncode=1, cmd=["git", "show", "--format=%B", "-s", hash_value]
+    )
+
+    with pytest.raises(GitCommitNotFoundException):
+        get_commit_message_of_hash(hash_value)
+
+
+@patch(
+    "src.commitlint.git_helpers.get_commit_message_of_hash",
+    return_value="From commit message",
+)
+def test_get_commit_messages_of_hash_range_success(
+    _mock_get_commit_message_of_hash, mock_subprocess
+):
+    from_hash = "abc123"
+    to_hash = "def456"
+    expected_output = (
+        "Commit message 1\n========commit-delimiter========\nCommit message 2"
+    )
+    mock_subprocess.check_output.return_value = expected_output
+
+    result = get_commit_messages_of_hash_range(from_hash, to_hash)
+
+    assert result == ["From commit message", "Commit message 1", "Commit message 2"]
+    mock_subprocess.check_output.assert_called_once_with(
+        [
+            "git",
+            "log",
+            f"--format=%B{DELIMITER}",
+            "--reverse",
+            f"{from_hash}..{to_hash}",
+        ],
+        text=True,
+        stderr=subprocess.PIPE,
+    )
+
+
+@patch(
+    "src.commitlint.git_helpers.get_commit_message_of_hash",
+    return_value="From commit message",
+)
+def test_get_commit_messages_of_hash_range_failure(
+    _mock_get_commit_message_of_hash, mock_subprocess
+):
+    from_hash = "invalid_hash"
+    to_hash = "def456"
+    mock_subprocess.check_output.side_effect = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=[
+            "git",
+            "log",
+            f"--format=%B{DELIMITER}",
+            "--reverse",
+            f"{from_hash}..{to_hash}",
+        ],
+    )
+
+    with pytest.raises(GitInvalidCommitRangeException):
+        get_commit_messages_of_hash_range(from_hash, to_hash)


### PR DESCRIPTION
# Description
- Added support for commitlint with hash: `--hash`. 
- Added support for commitlint with hash range: `--from-hash` & `--to-hash`.
    - Displayed multiple error messages
- Added exception handling and message display for commitlint errors (such as git errors).
- Added/Updated tests for above mentioned code.
- Minor fix on constants and messages variable names.

# Linked Issue
Fixes #6 