### PR TITLE
feat: add fail_on_error parameter support on github actions

### DIFF
--- a/.github/workflows/test_action.yaml
+++ b/.github/workflows/test_action.yaml
@@ -13,6 +13,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run commitlint
+        id: commitlintrun
         uses: ./ # Uses an action in the root directory
         # or use a released GitHub Action
         # uses: opensource-nepal/commitlint@v0.2.1
+        with:
+          fail_on_error: false
+
+      - name: Check Output
+        run: |
+          echo 'Status - ${{ steps.commitlintrun.outputs.status }}'
+          echo 'Exit Code - ${{ steps.commitlintrun.outputs.exit_code }}'
+
+          # Check commitlintrun status
+          if [ "${{ steps.commitlintrun.outputs.status }}" = "failure" ]; then
+            echo "Failing the job manually because Commitlint status is failure."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ jobs:
 
 > **_NOTE:_** commitlint GitHub Actions will only be triggered by "push" or "pull_request" events.
 
+#### GitHub Action Inputs
+
+| #   | Name              | Type       | Default    | Description |
+| --- | ----------------- | -----------| -----------| ----------- |
+|  1  | **fail_on_error** | Boolean    | true       |  Determines whether the GitHub Action should fail when encountering an error. |
+
+
+#### GitHub Action Outputs
+
+| #   | Name           | Type          | Description  |
+| --- | -------------- | --------------| ------------ |
+| 1   | **exit_code**  | Integer       | The exit code indicating the success or failure of the GitHub Actions workflow. |
+| 2   | **status**     |'failure' \| 'success'| The status of the GitHub Actions workflow, indicating success or failure. |
+
 ## Contribution
 
 We appreciate feedback and contribution to this package. To get started please see our [contribution guide](./CONTRIBUTING.md).

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,17 @@
 name: "Conventional Commitlint"
 description: "A GitHub Action to check conventional commit message"
+inputs:
+  fail_on_error:
+    description: Whether to fail the workflow if commit messages don't follow conventions.
+    default: 'true'
+    required: false
+outputs:
+    status:
+      description: Status
+      value: ${{ steps.commitlint.outputs.status }}
+    exit_code:
+      description: Exit Code
+      value: ${{ steps.commitlint.outputs.exit_code }}
 branding:
   color: "red"
   icon: "git-commit"
@@ -42,5 +54,8 @@ runs:
     # checking the commits (for both push and pull_request)
     - name: Check the commits
       id: commitlint
-      run: python ${{ github.action_path }}/github_actions/run.py
+      run: |
+        python ${{ github.action_path }}/github_actions/run.py
       shell: bash
+      env:
+        INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}

--- a/github_actions/run.py
+++ b/github_actions/run.py
@@ -2,13 +2,23 @@
 This script contains actions to be taken based on GitHub events,
 specifically for push and pull_request events.
 """
+import os
 import subprocess
 import sys
+from typing import Optional, Union
 
 from event import GithubEvent
 
+# Events
 EVENT_PUSH = "push"
 EVENT_PULL_REQUEST = "pull_request"
+
+# Inputs
+INPUT_FAIL_ON_ERROR = "INPUT_FAIL_ON_ERROR"
+
+# Status
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
 
 
 def _handle_pr_event(event: GithubEvent) -> None:
@@ -55,6 +65,67 @@ def _handle_push_event(event: GithubEvent) -> None:
         raise EnvironmentError("Unable to retrieve From hash and To hash") from None
 
 
+def _write_output(name: str, value: Union[str, int]) -> None:
+    """
+    Writes an output to the GitHub Actions environment.
+
+    Args:
+        name (str): The name of the output variable.
+        value: The value to be assigned to the output variable.
+
+    Raises:
+        OSError: If there is an issue opening or writing to the output file.
+    """
+    output_file_path = os.environ.get("GITHUB_OUTPUT", "")
+    with open(file=output_file_path, mode="a", encoding="utf-8") as output_file:
+        output_file.write(f"{name}={value}\n")
+
+
+def _get_input(key: str) -> Optional[str]:
+    """
+    Reads the github action input
+
+    Args:
+        key (str): The environment variable to parse
+
+    Returns:
+        str or None: The value of the input or None if it is not set
+    """
+    return os.environ.get(key)
+
+
+def _parse_boolean_input(val: Optional[str]) -> bool:
+    """
+    Parses the input environment key of boolean type in the YAML 1.2
+    "core schema" specification.
+    Support boolean input list:
+    `true | True | TRUE | false | False | FALSE` .
+    ref: https://yaml.org/spec/1.2/spec.html#id2804923
+
+    Args:
+        key (str, optional): The name of the environment variable to parse.
+
+    Returns:
+        bool: The parsed boolean value.
+
+    Raises:
+        TypeError: If the environment variable's value does not meet the
+        YAML 1.2 "core schema" specification for booleans.
+    """
+
+    if val in {"true", "True", "TRUE"}:
+        return True
+    if val in {"false", "False", "FALSE"}:
+        return False
+    raise TypeError(
+        """
+        Input does not meet YAML 1.2 "Core Schema" specification.\n'
+        Support boolean input list:
+        `true | True | TRUE | false | False | FALSE
+        """
+    )
+
+
 def _check_commits(from_hash: str, to_hash: str) -> None:
     """Check commits using commitlint.
 
@@ -75,8 +146,17 @@ def _check_commits(from_hash: str, to_hash: str) -> None:
             text=True,
         ).strip()
         sys.stdout.write(f"{output}\n")
-    except subprocess.CalledProcessError:
-        sys.exit(1)
+
+        _write_output("status", STATUS_SUCCESS)
+        _write_output("exit_code", 0)
+
+    except subprocess.CalledProcessError as error:
+        _write_output("status", STATUS_FAILURE)
+        _write_output("exit_code", error.returncode)
+        val = _get_input(INPUT_FAIL_ON_ERROR)
+        fail_on_error = _parse_boolean_input(val)
+        if fail_on_error:
+            sys.exit(1)
 
 
 def main() -> None:


### PR DESCRIPTION
## Description

The current GitHub Actions fail if `commitlint` throws an error. 

This pull request adds a new boolean parameter, fail_on_error, to GitHub Actions. This parameter will determine whether to fail the CI or proceed to the next step when `commitlint` throws an error. The default value for this parameter will be `true`.

The fail_on_error parameter is set to false when the user wants to ignore the commit message validation or handle the error in their own way.

## Related Issue

Fixes #14 

## Type of Change

Please mark the appropriate option below to describe the type of change your pull request introduces:

-   [ ] Bug fix
-   [x] New feature
-   [ ] Enhancement
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] Other (please specify)

## Checklist

-   [x] My pull request has a clear title and description.
-   [x] I have used [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
        Examples: `"fix: Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
-   [x] I have added/updated the necessary documentation on `README.md`.
-   [x] I have added appropriate test cases (if applicable) to ensure the changes are functioning correctly.


By submitting this pull request, I confirm that I have read and complied with the contribution guidelines of this project.
