### PR TITLE
test: refactor tests for system exit

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@
 
 from unittest.mock import MagicMock, call, mock_open, patch
 
+import pytest
+
 from commitlint.cli import get_args, main
 from commitlint.exceptions import CommitlintException
 from commitlint.messages import (
@@ -137,15 +139,14 @@ class TestCLIMain:
         ),
     )
     @patch("sys.stderr.write")
-    @patch("sys.exit")
     def test__main__invalid_commit_message(
         self,
-        mock_sys_exit,
         mock_stderr_write,
         *_,
     ):
-        main()
-        mock_sys_exit.assert_called_with(1)
+        with pytest.raises(SystemExit):
+            main()
+
         mock_stderr_write.assert_has_calls(
             [
                 call("⧗ Input:\nInvalid commit message\n\n"),
@@ -166,15 +167,14 @@ class TestCLIMain:
         ),
     )
     @patch("sys.stderr.write")
-    @patch("sys.exit")
     def test__main__invalid_commit_message_using_skip_detail(
         self,
-        mock_sys_exit,
         mock_stderr_write,
         *_,
     ):
-        main()
-        mock_sys_exit.assert_called_with(1)
+        with pytest.raises(SystemExit):
+            main()
+
         mock_stderr_write.assert_has_calls(
             [
                 call("⧗ Input:\nInvalid commit message\n\n"),
@@ -199,13 +199,11 @@ class TestCLIMain:
         return_value=MagicMock(file="path/to/file.txt", skip_detail=False, quiet=False),
     )
     @patch("sys.stderr.write")
-    @patch("sys.exit")
     @patch("builtins.open", mock_open(read_data="Invalid commit message 2"))
-    def test__main__invalid_commit_message_with_file(
-        self, mock_sys_exit, mock_stderr_write, *_
-    ):
-        main()
-        mock_sys_exit.assert_called_with(1)
+    def test__main__invalid_commit_message_with_file(self, mock_stderr_write, *_):
+        with pytest.raises(SystemExit):
+            main()
+
         mock_stderr_write.assert_has_calls(
             [
                 call("⧗ Input:\nInvalid commit message 2\n\n"),
@@ -239,13 +237,14 @@ class TestCLIMain:
     )
     @patch("commitlint.cli.get_commit_message_of_hash")
     @patch("sys.stderr.write")
-    @patch("sys.exit")
     def test__main__invalid_commit_message_with_hash(
-        self, mock_sys_exit, mock_stderr_write, mock_get_commit_message_of_hash, *_
+        self, mock_stderr_write, mock_get_commit_message_of_hash, *_
     ):
         mock_get_commit_message_of_hash.return_value = "Invalid commit message"
-        main()
-        mock_sys_exit.assert_called_with(1)
+
+        with pytest.raises(SystemExit):
+            main()
+
         mock_stderr_write.assert_has_calls(
             [
                 call("⧗ Input:\nInvalid commit message\n\n"),
@@ -292,16 +291,16 @@ class TestCLIMain:
     )
     @patch("sys.stderr.write")
     @patch("commitlint.cli.get_commit_messages_of_hash_range")
-    @patch("sys.exit")
     def test__main__invalid_commit_message_with_hash_range(
-        self, mock_sys_exit, mock_get_commit_messages, *_
+        self, mock_get_commit_messages, *_
     ):
         mock_get_commit_messages.return_value = [
             "Invalid commit message 1",
             "Invalid commit message 2",
         ]
-        main()
-        mock_sys_exit.assert_called_with(1)
+
+        with pytest.raises(SystemExit):
+            main()
 
     # main : exception handling
 
@@ -315,13 +314,14 @@ class TestCLIMain:
         "commitlint.cli.lint_commit_message",
     )
     @patch("sys.stderr.write")
-    @patch("sys.exit")
     def test__main__handle_exceptions(
-        self, mock_sys_exit, mock_stderr_write, mock_lint_commit_message, *_
+        self, mock_stderr_write, mock_lint_commit_message, *_
     ):
         mock_lint_commit_message.side_effect = CommitlintException("Test message")
-        main()
-        mock_sys_exit.assert_called_with(1)
+
+        with pytest.raises(SystemExit):
+            main()
+
         mock_stderr_write.assert_called_with("Test message\n")
 
     @patch(
@@ -337,11 +337,12 @@ class TestCLIMain:
     )
     @patch("sys.stdout.write")
     @patch("sys.stderr.write")
-    @patch("sys.exit")
     def test__main__quiet_option_with_invalid_commit_message(
-        self, mock_sys_exit, mock_stderr_write, mock_stdout_write, *_
+        self, mock_stderr_write, mock_stdout_write, *_
     ):
-        main()
+        with pytest.raises(SystemExit):
+            main()
+
         mock_stderr_write.assert_not_called()
         mock_stdout_write.assert_not_called()
 
@@ -358,14 +359,12 @@ class TestCLIMain:
     )
     @patch("sys.stdout.write")
     @patch("sys.stderr.write")
-    @patch("sys.exit")
     def test__main__quiet_option_with_valid_commit_message(
-        self, mock_sys_exit, mock_stderr_write, mock_stdout_write, *_
+        self, mock_stderr_write, mock_stdout_write, *_
     ):
         main()
         mock_stderr_write.assert_not_called()
         mock_stdout_write.assert_not_called()
-        mock_sys_exit.assert_not_called()
 
     @patch(
         "commitlint.cli.get_args",
@@ -402,14 +401,12 @@ class TestCLIMain:
         ),
     )
     @patch("commitlint.cli.get_commit_messages_of_hash_range")
-    @patch("sys.exit")
     @patch("sys.stdout.write")
     @patch("sys.stderr.write")
     def test__invalid_commit_message_with_hash_range_in_quiet(
         self,
         mock_stderr_write,
         mock_stdout_write,
-        mock_sys_exit,
         mock_get_commit_messages,
         *_,
     ):
@@ -417,7 +414,9 @@ class TestCLIMain:
             "Invalid commit message 1",
             "Invalid commit message 2",
         ]
-        main()
+
+        with pytest.raises(SystemExit):
+            main()
+
         mock_stderr_write.assert_not_called()
-        mock_sys_exit.assert_called_once_with(1)
         mock_stdout_write.assert_not_called()


### PR DESCRIPTION
## Description

In our tests, we are currently mocking `sys.exit`. Due to this mocking, the application logic does not exit immediately in the tests, resulting in many errors failing. Therefore, this issue is being addressed through this PR by removing the mock and checking for the `SystemExit` exception to be raised.

## Related Issue

N/A

## Type of Change

Please mark the appropriate option below to describe the type of change your pull request introduces:

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Enhancement
-   [ ] Documentation update
-   [x] Refactor
-   [x] Other (Tests)

## Checklist

-   [x] My pull request has a clear title and description.
-   [x] I have used [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
        Examples: `"fix: Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
-   [ ] I have added/updated the necessary documentation on `README.md`.
-   [ ] I have added appropriate test cases (if applicable) to ensure the changes are functioning correctly.

## Additional Notes

[Add any additional notes or context that you think the reviewers should know about.]

By submitting this pull request, I confirm that I have read and complied with the contribution guidelines of this project.
