### PR TITLE
fix: handle commit message starting with #

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ For more details, please refer to the Conventional Commits specification at http
    pre-commit install --hook-type commit-msg
    ```
 
-> **_NOTE:_** Installing using only `pre-commit install` will not work.
+   Installing using only `pre-commit install` will not work.
+
+> **_NOTE:_** Avoid using commit messages that start with '#'.
+> This might result in unexpected behavior with commitlint.
 
 ### For GitHub Actions
 
@@ -150,6 +153,9 @@ Check commit message from file:
 ```shell
 $ commitlint --file /foo/bar/commit-message.txt
 ```
+
+> **_NOTE:_** For `--file` option, avoid using commit messages that start with '#'.
+> This might result in unexpected behavior with commitlint.
 
 Check commit message of a hash:
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,10 +2,3 @@
 
 # Disabling comments
 comment: false
-
-# Disabling Github checks
-github_checks: false
-coverage:
-  status:
-    project: off
-    patch: off

--- a/src/commitlint/linter/_linter.py
+++ b/src/commitlint/linter/_linter.py
@@ -16,7 +16,7 @@ from .validators import (
 
 
 def lint_commit_message(
-    commit_message: str, skip_detail: bool = False
+    commit_message: str, skip_detail: bool = False, strip_comments: bool = False
 ) -> Tuple[bool, List[str]]:
     """
     Lints a commit message.
@@ -25,6 +25,8 @@ def lint_commit_message(
         commit_message (str): The commit message to be linted.
         skip_detail (bool, optional): Whether to skip the detailed error linting
             (default is False).
+        strip_comments (bool, optional): Whether to remove comments from the
+            commit message (default is False).
 
     Returns:
         Tuple[bool, List[str]]: Returns success as a first element and list of errors
@@ -35,8 +37,9 @@ def lint_commit_message(
 
     # perform processing and pre checks
     # removing unnecessary commit comments
-    console.verbose("removing comments from the commit message")
-    commit_message = remove_comments(commit_message)
+    if strip_comments:
+        console.verbose("removing comments from the commit message")
+        commit_message = remove_comments(commit_message)
 
     # checking if commit message should be ignored
     console.verbose("checking if the commit message is in ignored list")

--- a/src/commitlint/linter/utils.py
+++ b/src/commitlint/linter/utils.py
@@ -24,10 +24,29 @@ def is_ignored(commit_message: str) -> bool:
     return bool(re.match(IGNORE_COMMIT_PATTERNS, commit_message))
 
 
-def remove_comments(msg: str) -> str:
+def remove_comments(commit_message: str) -> str:
     """Removes comments from the commit message.
 
-    For `git commit --verbose`, excluding the diff generated message,
+    Args:
+        commit_message(str): The commit message to remove comments.
+
+    Returns:
+        str: The commit message without comments.
+    """
+    commit_message = remove_diff_from_commit_message(commit_message)
+
+    lines: List[str] = []
+    for line in commit_message.split("\n"):
+        if not line.startswith("#"):
+            lines.append(line)
+
+    return "\n".join(lines)
+
+
+def remove_diff_from_commit_message(commit_message: str) -> str:
+    """Removes commit diff from the commit message.
+
+    For `git commit --verbose`, removing the diff generated message,
     for example:
 
     ```bash
@@ -40,18 +59,10 @@ def remove_comments(msg: str) -> str:
     ```
 
     Args:
-        msg(str): The commit message to remove comments.
+        commit_message (str): The commit message to remove diff.
 
     Returns:
-        str: The commit message without comments.
+        str: The commit message without diff.
     """
-
-    lines: List[str] = []
-    for line in msg.split("\n"):
-        if "# ------------------------ >8 ------------------------" in line:
-            # ignoring all the verbose message below this line
-            break
-        if not line.startswith("#"):
-            lines.append(line)
-
-    return "\n".join(lines)
+    verbose_commit_separator = "# ------------------------ >8 ------------------------"
+    return commit_message.split(verbose_commit_separator)[0].strip()

--- a/tests/fixtures/linter.py
+++ b/tests/fixtures/linter.py
@@ -44,13 +44,6 @@ LINTER_FIXTURE_PARAMS: Tuple[Tuple[str, bool, List[str], List[str]], ...] = (
     ("feat: add new feature\n\nthis is body\n\ntest", True, []),
     ("feat: add new feature\n", True, []),
     ("build(deps-dev): bump @babel/traverse from 7.22.17 to 7.24.0", True, []),
-    ("feat(scope): add new feature\n#this is a comment", True, []),
-    (
-        "fix: fixed a bug\n\nthis is body\n"
-        "# ------------------------ >8 ------------------------\nDiff message",
-        True,
-        [],
-    ),
     ("feat!: breaking feature", True, []),
     # ignored commits (success)
     ("Merge pull request #123", True, []),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,6 +193,20 @@ class TestCLIMain:
         "commitlint.cli.get_args",
         return_value=MagicMock(file="path/to/file.txt", skip_detail=False, quiet=False),
     )
+    @patch(
+        "builtins.open",
+        mock_open(read_data="feat: valid commit message 2\n#this is a comment"),
+    )
+    def test__main__valid_commit_message_and_comments_with_file(
+        self, _mock_get_args, _mock_output_error, mock_output_success
+    ):
+        main()
+        mock_output_success.assert_called_with(f"{VALIDATION_SUCCESSFUL}")
+
+    @patch(
+        "commitlint.cli.get_args",
+        return_value=MagicMock(file="path/to/file.txt", skip_detail=False, quiet=False),
+    )
     @patch("builtins.open", mock_open(read_data="Invalid commit message 2"))
     def test__main__invalid_commit_message_with_file(
         self, _mock_get_args, mock_output_error, _mock_output_success

--- a/tests/test_linter/test__linter.py
+++ b/tests/test_linter/test__linter.py
@@ -1,14 +1,14 @@
 # type: ignore
 # pylint: disable=all
 
+from unittest.mock import patch
+
 import pytest
 
 from commitlint.constants import COMMIT_HEADER_MAX_LENGTH
 from commitlint.linter import lint_commit_message
-from commitlint.messages import (
-    HEADER_LENGTH_ERROR,
-    INCORRECT_FORMAT_ERROR,
-)
+from commitlint.messages import HEADER_LENGTH_ERROR, INCORRECT_FORMAT_ERROR
+
 from ..fixtures.linter import LINTER_FIXTURE_PARAMS
 
 
@@ -28,6 +28,23 @@ def test__lint_commit_message__skip_detail(fixture_data):
     commit_message, expected_success, _ = fixture_data
     success, _ = lint_commit_message(commit_message, skip_detail=True)
     assert success == expected_success
+
+
+def test__lint_commit_message__remove_comments_if_strip_comments_is_True():
+    commit_message = "feat(scope): add new feature\n#this is a comment"
+    success, errors = lint_commit_message(commit_message, strip_comments=True)
+    assert success is True
+    assert errors == []
+
+
+@patch("commitlint.linter._linter.remove_comments")
+def test__lint_commit_message__calls_remove_comments_if_strip_comments_is_True(
+    mock_remove_comments,
+):
+    commit_message = "feat(scope): add new feature"
+    mock_remove_comments.return_value = commit_message
+    lint_commit_message(commit_message, strip_comments=True)
+    mock_remove_comments.assert_called_once()
 
 
 def test__lint_commit_message__skip_detail_returns_header_length_error_message():

--- a/tests/test_linter/test_utils/test_remove_diff_from_commit_message.py
+++ b/tests/test_linter/test_utils/test_remove_diff_from_commit_message.py
@@ -1,0 +1,29 @@
+# type: ignore
+# pylint: disable=all
+
+from commitlint.linter.utils import remove_diff_from_commit_message
+
+
+def test__remove_diff_from_commit_message__without_diff():
+    input_msg = "Commit message without diff"
+    expected_output = "Commit message without diff"
+    result = remove_diff_from_commit_message(input_msg)
+    assert result == expected_output
+
+
+def test__remove_diff_from_commit_message__with_diff():
+    input_msg = (
+        "Fix a bug\n"
+        "# ------------------------ >8 ------------------------\n"
+        "Diff message"
+    )
+    expected_output = "Fix a bug"
+    result = remove_diff_from_commit_message(input_msg)
+    assert result == expected_output
+
+
+def test__remove_diff_from_commit_message__strips_commit_message():
+    input_msg = "Commit message\n "
+    expected_output = "Commit message"
+    result = remove_diff_from_commit_message(input_msg)
+    assert result == expected_output


### PR DESCRIPTION
## Description
Handled commit message starting with '#'.

### How was the issue fixed?

Comments are removed only on the file as a commit source (--file), as comments are only allowed through the file from git. This fix resolved the issue on GitHub Actions, CLI which uses hash values and direct commit messages.

For the file as a commit source, the linter will still remove the comments, including valid commits starting with '#'. A commit message starting with '#' will be treated as an empty commit. Since a commit starting with '#' does not follow the conventional commit specification, treating it as an empty commit yields the same result. Additionally, we display the full commit message in the input section, therefore the commit message will not be empty in this case.

Furthermore, the README document is updated mentioning not to use the commit messages that start with '#'.

### Development Summary
- Removed comments only on `--file` (since the commit message from hash doesn't contain comments). This improves performance.
- Displayed full commit on 'Input' section of output.
- Created function `remove_diff_from_commit_message` for removing diff from the commits.
- Updated README doc for not using commit messages that start with '#'.
- Allowed codecov checks for coverage.

## Related Issue

Fixes #49

## Type of Change

Please mark the appropriate option below to describe the type of change your pull request introduces:

-   [x] Bug fix
-   [ ] New feature
-   [ ] Enhancement
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] Other (please specify)

## Checklist

-   [x] My pull request has a clear title and description.
-   [x] I have used [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
        Examples: `"fix: Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
-   [x] I have added/updated the necessary documentation on `README.md`.
-   [x] I have added appropriate test cases (if applicable) to ensure the changes are functioning correctly.

## Additional Notes

[Add any additional notes or context that you think the reviewers should know about.]

By submitting this pull request, I confirm that I have read and complied with the contribution guidelines of this project.
