### PR TITLE
fix: fix major version tag fetch on pre-commit autoupdate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,17 +27,9 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
-          # removing previous tags
-          git tag -d v${{ steps.release.outputs.major }} || true
-          git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
-          git push origin :v${{ steps.release.outputs.major }} || true
-          git push origin :v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
-
-          # creating new tags
-          git tag -a v${{ steps.release.outputs.major }} -m "Release v${{ steps.release.outputs.major }}"
-          git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}"
-          git push origin v${{ steps.release.outputs.major }}
-          git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
+          # create and push major version tag
+          git tag v${{ steps.release.outputs.major }}
+          git push origin v${{ steps.release.outputs.major }} -f
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more details, please refer to the Conventional Commits specification at http
    repos:
       ...
       - repo: https://github.com/opensource-nepal/commitlint
-        rev: v1.0.0
+        rev: v1.2.0
         hooks:
           - id: commitlint
       ...


### PR DESCRIPTION
## Description
The annotated tag with a major version (e.g., v1) was created with a new timestamp. Therefore, pre-commit treated the major version tag as the latest tag.

Fix: 
- Created simple tags instead of annotated tags. Simple tags will reference the commit timestamp.
- Removed creation of minor version 2-digit tag.


## Related Issue

Relates #64

## Type of Change

Please mark the appropriate option below to describe the type of change your pull request introduces:

-   [x] Bug fix
-   [ ] New feature
-   [ ] Enhancement
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] Other (please specify)

## Checklist

-   [x] My pull request has a clear title and description.
-   [x] I have used [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
        Examples: `"fix: Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
-   [ ] I have added/updated the necessary documentation on `README.md`.
-   [ ] I have added appropriate test cases (if applicable) to ensure the changes are functioning correctly.


By submitting this pull request, I confirm that I have read and complied with the contribution guidelines of this project.