### PR TITLE
fix: skip the header length check and configure header length

### DIFF
--- a/src/commitlint/linter/_linter.py
+++ b/src/commitlint/linter/_linter.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 from .. import console
 from .utils import is_ignored, remove_comments
 from .validators import (
+    CommitValidator,
     HeaderLengthValidator,
     PatternValidator,
     SimplePatternValidator,
@@ -16,12 +17,18 @@ from .validators import (
 
 
 def lint_commit_message(
-    commit_message: str, skip_detail: bool = False, strip_comments: bool = False
+    commit_message: str,
+    max_header_length: int,
+    skip_detail: bool = False,
+    disable_max_header_length: bool = False,
+    strip_comments: bool = False,
 ) -> Tuple[bool, List[str]]:
     """
     Lints a commit message.
 
     Args:
+        disable_max_header_length: flag to disable the max header length check
+        max_header_length: maximum length of commit message header
         commit_message (str): The commit message to be linted.
         skip_detail (bool, optional): Whether to skip the detailed error linting
             (default is False).
@@ -47,16 +54,30 @@ def lint_commit_message(
         console.verbose("commit message ignored, skipping lint")
         return True, []
 
+    validator_instances: List[CommitValidator] = []
+
+    if not disable_max_header_length:
+        validator_instances.append(
+            HeaderLengthValidator(
+                commit_message=commit_message,
+                **{"max_header_length": max_header_length},  # type: ignore
+            )
+        )
+
     # for skip_detail check
     if skip_detail:
         console.verbose("running simple validators for linting")
+
+        validator_instances.append(
+            SimplePatternValidator(commit_message=commit_message)
+        )
+
         return run_validators(
-            commit_message,
-            validator_classes=[HeaderLengthValidator, SimplePatternValidator],
+            validator_classes=validator_instances,
             fail_fast=True,
         )
 
+    validator_instances.append(PatternValidator(commit_message=commit_message))
+
     console.verbose("running detailed validators for linting")
-    return run_validators(
-        commit_message, validator_classes=[HeaderLengthValidator, PatternValidator]
-    )
+    return run_validators(validator_classes=validator_instances)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -459,3 +459,46 @@ class TestCLIMainQuiet:
 
         mock_stderr_write.assert_not_called()
         mock_stdout_write.assert_not_called()
+
+
+class TestCliHeaderLength:
+    @patch(
+        "commitlint.cli.get_args",
+        return_value=ArgsMock(
+            commit_message="feat: add method 'formatEnglishDate' \
+                           and 'formatEnglishDateInNepali' (#165)",
+            quiet=True,
+            max_header_length=20,
+        ),
+    )
+    @patch("sys.stdout.write")
+    @patch("sys.stderr.write")
+    def test__main__quiet_option_with_header_max_length(
+        self, mock_stderr_write, mock_stdout_write, *_
+    ):
+        with pytest.raises(SystemExit):
+            main()
+
+        mock_stderr_write.assert_not_called()
+        mock_stdout_write.assert_not_called()
+
+    @patch(
+        "commitlint.cli.get_args",
+        return_value=ArgsMock(
+            commit_message="feat: add method 'formatEnglishDate' \
+                               and 'formatEnglishDateInNepali' (#165)",
+            quiet=True,
+            max_header_length=20,
+            disable_header_length_check=True,
+        ),
+    )
+    @patch("sys.stdout.write")
+    @patch("sys.stderr.write")
+    def test__with_both_header_max_length_and_disabled_max_header_length_check(
+        self, mock_stderr_write, mock_stdout_write, *_
+    ):
+        with pytest.raises(CommitlintException):
+            main()
+
+        mock_stderr_write.assert_not_called()
+        mock_stdout_write.assert_not_called()

--- a/tests/test_linter/test__linter.py
+++ b/tests/test_linter/test__linter.py
@@ -19,20 +19,35 @@ def fixture_data(request):
 
 def test_lint_commit_message(fixture_data):
     commit_message, expected_success, expected_errors = fixture_data
-    success, errors = lint_commit_message(commit_message, skip_detail=False)
+    success, errors = lint_commit_message(
+        commit_message,
+        skip_detail=False,
+        disable_max_header_length=False,
+        max_header_length=COMMIT_HEADER_MAX_LENGTH,
+    )
     assert success == expected_success
     assert errors == expected_errors
 
 
 def test__lint_commit_message__skip_detail(fixture_data):
     commit_message, expected_success, _ = fixture_data
-    success, _ = lint_commit_message(commit_message, skip_detail=True)
+    success, _ = lint_commit_message(
+        commit_message,
+        skip_detail=True,
+        disable_max_header_length=False,
+        max_header_length=COMMIT_HEADER_MAX_LENGTH,
+    )
     assert success == expected_success
 
 
 def test__lint_commit_message__remove_comments_if_strip_comments_is_True():
     commit_message = "feat(scope): add new feature\n#this is a comment"
-    success, errors = lint_commit_message(commit_message, strip_comments=True)
+    success, errors = lint_commit_message(
+        commit_message,
+        strip_comments=True,
+        disable_max_header_length=False,
+        max_header_length=COMMIT_HEADER_MAX_LENGTH,
+    )
     assert success is True
     assert errors == []
 
@@ -43,19 +58,55 @@ def test__lint_commit_message__calls_remove_comments_if_strip_comments_is_True(
 ):
     commit_message = "feat(scope): add new feature"
     mock_remove_comments.return_value = commit_message
-    lint_commit_message(commit_message, strip_comments=True)
+    lint_commit_message(
+        commit_message,
+        strip_comments=True,
+        disable_max_header_length=False,
+        max_header_length=COMMIT_HEADER_MAX_LENGTH,
+    )
     mock_remove_comments.assert_called_once()
 
 
 def test__lint_commit_message__skip_detail_returns_header_length_error_message():
     commit_message = "Test " + "a" * (COMMIT_HEADER_MAX_LENGTH + 1)
-    success, errors = lint_commit_message(commit_message, skip_detail=True)
+    success, errors = lint_commit_message(
+        commit_message,
+        skip_detail=True,
+        disable_max_header_length=False,
+        max_header_length=COMMIT_HEADER_MAX_LENGTH,
+    )
     assert success is False
     assert errors == [HEADER_LENGTH_ERROR]
 
 
 def test__lint_commit_message__skip_detail_returns_invalid_format_error_message():
     commit_message = "Test invalid commit message"
-    success, errors = lint_commit_message(commit_message, skip_detail=True)
+    success, errors = lint_commit_message(
+        commit_message,
+        skip_detail=True,
+        disable_max_header_length=False,
+        max_header_length=COMMIT_HEADER_MAX_LENGTH,
+    )
     assert success is False
     assert errors == [INCORRECT_FORMAT_ERROR]
+
+
+def test__disable_header_length_check():
+    commit_message = "feat: this is test for disabling the header length check (#77)"
+
+    success, errors = lint_commit_message(
+        commit_message,
+        skip_detail=True,
+        disable_max_header_length=True,
+        max_header_length=COMMIT_HEADER_MAX_LENGTH,
+    )
+    assert success is True
+
+
+def test__max_header_length_test():
+    commit_message = "feat: this is test for disabling the header length check (#77)"
+    success, errors = lint_commit_message(
+        commit_message, skip_detail=True, max_header_length=20
+    )
+    assert success is False
+    assert errors == [HEADER_LENGTH_ERROR]


### PR DESCRIPTION
## Description

Allow the  users to make the header length configurable and also allow disable header length check using a flag.


Introduced two flags

`--max-header-length`
`--disable-header-length-check`

## Related Issue

Fixes #67 

## Type of Change

Please mark the appropriate option below to describe the type of change your pull request introduces:

-   [x] Bug fix
-   [x] New feature
-   [ ] Enhancement
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] Other (please specify)

## Checklist

-   [x] My pull request has a clear title and description.
-   [x] I have used [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
        Examples: `"fix: Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
-   [ ] I have added/updated the necessary documentation on `README.md`.
-   [ ] I have added appropriate test cases (if applicable) to ensure the changes are functioning correctly.

## Additional Notes

There is one issue with HEADER_LENGTH_ERROR be cause of COMMIT_HEADER_MAX_LENGTH constant. 

I tried to set "%s" in the message but it seems to fail the tests because of fixers LINTER_FIXTURE_PARAMS and we need some way to pass the value to this fixture .

By submitting this pull request, I confirm that I have read and complied with the contribution guidelines of this project.
