### PR TITLE
feat(console): add color to standard output and standard error

### DIFF
--- a/src/commitlint/console.py
+++ b/src/commitlint/console.py
@@ -3,8 +3,6 @@ This module provides functions for displaying outputs related to commitlint.
 
 NOTE: If any future changes are made to the output implementation,
 they will be done from here.
-
-
 """
 
 import sys

--- a/src/commitlint/console.py
+++ b/src/commitlint/console.py
@@ -4,12 +4,24 @@ This module provides functions for displaying outputs related to commitlint.
 NOTE: If any future changes are made to the output implementation,
 they will be done from here.
 
-TODO: Add color on success and error (#5).
+
 """
 
 import sys
 
 from .config import config
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
+
+
+def green(text: str) -> str:
+    return f"{GREEN}{text}{RESET}"
+
+
+def red(text: str) -> str:
+    return f"{RED}{text}{RESET}"
 
 
 def success(message: str) -> None:
@@ -22,7 +34,7 @@ def success(message: str) -> None:
     if config.quiet:
         return
 
-    sys.stdout.write(f"{message}\n")
+    sys.stdout.write(f"{green(message)}\n")
 
 
 def error(message: str) -> None:
@@ -35,7 +47,7 @@ def error(message: str) -> None:
     if config.quiet:
         return
 
-    sys.stderr.write(f"{message}\n")
+    sys.stderr.write(f"{red(message)}\n")
 
 
 def verbose(message: str) -> None:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -11,7 +11,7 @@ from commitlint import console
 def test_success(mock_stdout: MagicMock, _mock_config: MagicMock):
     message = "Success message"
     console.success(message)
-    mock_stdout.write.assert_called_once_with(f"{message}\n")
+    mock_stdout.write.assert_called_once_with(f"{console.green(message)}\n")
 
 
 @patch("commitlint.console.config", quiet=True)
@@ -27,7 +27,7 @@ def test_success_for_quiet(mock_stdout: MagicMock, _mock_config: MagicMock):
 def test_error(mock_stderr: MagicMock, _mock_config: MagicMock):
     message = "Error message"
     console.error(message)
-    mock_stderr.write.assert_called_once_with(f"{message}\n")
+    mock_stderr.write.assert_called_once_with(f"{console.red(message)}\n")
 
 
 @patch("commitlint.console.config", quiet=True)


### PR DESCRIPTION
## Description
Added ANSI color to outputs and errors
## Issues
closes #5 
## Type of Change
-   [ ] Bug fix
-   [x] New feature
-   [ ] Enhancement
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] Other (please specify)

## Checklist

-   [x] My pull request has a clear title and description.
-   [x] I have used [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
        Examples: `"fix: Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
-   [x] I have added/updated the necessary documentation on `README.md`.
-   [x] I have added appropriate test cases (if applicable) to ensure the changes are functioning correctly.

## Additional Notes
The ANSI  escape sequences may not work for all devices, especially old ones. 