### PR TITLE
chore: bump actions to node 24 runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,10 @@ jobs:
         python-version: ['3.10']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -31,14 +31,14 @@ jobs:
           poetry install
 
       - name: Run Lint
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4
 
       - name: Run tests with coverage
         run: |
           poetry run pytest --cov=src/ --cov-report=xml --no-cov-on-fail
 
       - name: Send coverage to CodeCov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Commitlint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run commitlint
         # uses: opensource-nepal/commitlint@v1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - name: Release
         id: release
-        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.release_created }}
 
       - name: tag major and minor versions
@@ -32,7 +32,7 @@ jobs:
           git push origin v${{ steps.release.outputs.major }} -f
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: ${{ steps.release.outputs.release_created }}
         with:
           python-version: '3.x'
@@ -49,4 +49,4 @@ jobs:
 
       - name: Publish package
         if: ${{ steps.release.outputs.release_created }}
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Python
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: '3.10'
 


### PR DESCRIPTION
## Summary

GitHub deprecated the Node 20 runtime for actions, so every workflow run currently emits a "Node.js 20 actions are deprecated" warning — including for downstream users of `opensource-nepal/commitlint@v1`, since `action.yml` pulls in `actions/setup-python@v5.1.0` (Node 20).

This bumps every referenced action to a version running on Node 24:

| Action | Before | After | Where |
|---|---|---|---|
| `actions/setup-python` | `v5.1.0` | `v6.2.0` | `action.yml` (user-facing) |
| `actions/setup-python` | `v5` | `v6` | `ci.yaml`, `release-please.yml` |
| `actions/checkout` | `v4` | `v6` | all 3 workflows |
| `astral-sh/ruff-action` | `v3` | `v4` | `ci.yaml` |
| `codecov/codecov-action` | `v3` | `v6` | `ci.yaml` |
| `googleapis/release-please-action` | `v4.1.3` | `v5.0.0` | `release-please.yml` |
| `pypa/gh-action-pypi-publish` | `v1.13.0` | `v1.14.0` | `release-please.yml` (composite — bumped for parity) |

After this change, the deprecation warning is eliminated for downstream consumers of `opensource-nepal/commitlint@v1` (the user-facing surface) and for the repo's own `ci.yaml` / `commitlint.yaml` runs.

## Known residual warning (blocked on upstream)

`pypa/gh-action-pypi-publish@v1.14.0` is a composite action that internally calls `actions/setup-python@v5.6.0` (Node 20). This means the **release-please workflow will still emit a Node 20 warning on release runs only** — not on PRs or normal CI. `v1.14.0` is the latest available release (April 2026) and there's no open PR upstream tracking this; the residual warning will resolve when `pypa/gh-action-pypi-publish` bumps their internal `setup-python` reference.

## Compatibility notes

- **Runner version**: Node 24 actions require GitHub runner ≥ `v2.327.1`. Hosted runners are already past this.
- **`googleapis/release-please-action` v4 → v5**: manifest-based config is now required; this repo already has `release-please-config.json` + `.release-please-manifest.json`, so it should work without further changes. Worth eyeballing the next release-please run.
- **`astral-sh/ruff-action` v3 → v4**: some input names changed, but the CI step here is invoked with no inputs, so no migration needed.
- **`codecov/codecov-action` v3 → v6**: deprecated `file`/`plugin` inputs; this repo only passes `token`, `fail_ci_if_error`, `verbose` — all still supported.
- SHA-pinned actions kept their SHA-pinning style; new SHAs match their tagged versions.

## Test plan

- [ ] CI workflow runs green on this PR (checkout v6 + setup-python v6 + ruff v4 + codecov v6)
- [ ] Commitlint workflow passes against this PR's commits
- [ ] No "Node.js 20 actions are deprecated" warning appears in CI / commitlint workflow runs on this PR
- [ ] On next merge to `main`, release-please workflow runs without error (release-please-action v5, pypi-publish v1.14.0)