### PR TITLE
fix(action): bump setup-python to v6.2.0 to drop Node 20 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Python
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: '3.10'
 


### PR DESCRIPTION
## Description

`action.yml` pins `actions/setup-python@v5.1.0`, which runs on the Node.js 20
runtime. GitHub now emits a deprecation warning for Node 20 actions, so every
consumer of this action sees the warning in their workflow logs.

This bumps the pin to `actions/setup-python@v6.2.0`, which runs on Node.js 24
and clears the deprecation warning for all downstream users.

## Changes

- `action.yml`: `actions/setup-python@v5.1.0` → `@v6.2.0`

## Notes

- v5.x of setup-python (including v5.4.0–v5.6.0) still runs on Node 20; only
  v6.0.0+ moved to Node 24, hence the jump to v6.x.